### PR TITLE
Replace Ansible private API with configparser for vault config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,12 @@ on:
 jobs:
   test:
     name: Test on Python ${{ matrix.python-version }}
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
     - name: Checkout code
@@ -28,7 +28,7 @@ jobs:
     - name: Cache pip packages
       uses: actions/cache@v4
       with:
-        path: ~/Library/Caches/pip
+        path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
@@ -50,13 +50,13 @@ jobs:
         pytest -v --tb=short
 
     - name: Run pytest with coverage
-      if: matrix.python-version == '3.11'
+      if: matrix.python-version == '3.12'
       run: |
         pytest --cov=. --cov-report=xml --cov-report=term
 
     - name: Upload coverage to Codecov
-      if: matrix.python-version == '3.11'
-      uses: codecov/codecov-action@v4
+      if: matrix.python-version == '3.12'
+      uses: codecov/codecov-action@v5
       with:
         file: ./coverage.xml
         flags: unittests
@@ -65,7 +65,7 @@ jobs:
 
   lint:
     name: Code Quality
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code
@@ -74,29 +74,28 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
-    - name: Install linting tools
+    - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install black flake8 pylint
+        pip install -r requirements.txt
+        pip install -r requirements-dev.txt
 
     - name: Check code formatting with Black
       run: |
         black --check --diff *.py tests/
-      continue-on-error: true
 
     - name: Lint with flake8
       run: |
         # Stop the build if there are Python syntax errors or undefined names
         flake8 *.py tests/ --count --select=E9,F63,F7,F82 --show-source --statistics
-        # Exit-zero treats all errors as warnings
+        # Warnings (non-blocking)
         flake8 *.py tests/ --count --exit-zero --max-complexity=10 --max-line-length=100 --statistics
-      continue-on-error: true
 
   ansible-syntax:
     name: Ansible Syntax Check
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code
@@ -105,24 +104,21 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     - name: Install Ansible
       run: |
         python -m pip install --upgrade pip
-        pip install ansible
+        pip install -r requirements.txt
 
     - name: Check playbook syntax
       run: |
-        # Syntax check only - won't fail on missing vault password
-        ansible-playbook --syntax-check playbook_pipe.yml || true
-        ansible-playbook --syntax-check playbook_keyring.yml || true
-        # playbook_vault.yml requires vault password, skip it
-      continue-on-error: true
+        ansible-playbook --syntax-check playbook_pipe.yml
+        ansible-playbook --syntax-check playbook_keyring.yml
 
   security:
     name: Security Scan
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code
@@ -131,15 +127,14 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
-    - name: Install safety
+    - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install safety
-
-    - name: Check for known vulnerabilities
-      run: |
         pip install -r requirements.txt
-        safety check --json || true
-      continue-on-error: true
+        pip install pip-audit
+
+    - name: Audit dependencies for vulnerabilities
+      run: |
+        pip-audit -r requirements.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,10 @@ The project README recommends storing vault password scripts outside source cont
 
 ## Known Issues and Troubleshooting
 
+### Issue #3: ImportError with newer Ansible versions (RESOLVED)
+
+**Status**: Fixed - vault scripts now use Python's `configparser` instead of Ansible's private `get_ini_config_value` API which was removed in newer Ansible versions. The scripts read the `[vault]` section from `ansible.cfg` directly using the standard Ansible config search order (ANSIBLE_CONFIG env var > ./ansible.cfg > ~/.ansible.cfg > /etc/ansible/ansible.cfg).
+
 ### Issue #1: community.general.keyring fails with multiple Python versions
 
 **Status**: Open since April 2021

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ See issue [#1](https://github.com/docdyhr/ansible-keyring/issues/1) for troubles
 
 ## A simple solution without using community.general.keyring
 
-Use Keyring to set a 'test' acount with label 'test':
+Use Keyring to set a 'test' account with label 'test':
 
 ```cli
 keyring set test test
@@ -253,13 +253,13 @@ ansible-vault encrypt vars/api_key.yml
 
 ### Test ansible-vault with vault-keyring.py
 
-vault-keyring.py is automaticly used when defined in ansible.cfg
+vault-keyring.py is automatically used when defined in ansible.cfg
 
 ```cli
 ansible-vault view vars/api_key.yml --vault-password-file vault-keyring.py
 ```
 
-The below will also work as ansible-vault will automaticly detect and decrypt the vars/api_key.yml file with vault-keyring.py
+The below will also work as ansible-vault will automatically detect and decrypt the vars/api_key.yml file with vault-keyring.py
 
 ```cli
 ansible-vault view vars/api_key.yml
@@ -281,7 +281,7 @@ ansible-playbook playbook_vault.yml --vault-password-file vault-keyring.py
 ansible-playbook --vault-id vault-keyring.py playbook_vault.yml
 ```
 
-vault-keyring.py is automaticly detected and used when the credentials is defined in ansible.cfg, so this will also work:
+vault-keyring.py is automatically detected and used when the credentials are defined in ansible.cfg, so this will also work:
 
 ```cli
 ansible-playbook playbook_vault.yml
@@ -304,6 +304,14 @@ After implementing the vault-keyring method for getting usernames in vault-keyri
 **NB!** It's recommended to put any password files / scripts outside source control ie. git project folder for better security - example path: ***~/.ansible***
 
 ## Troubleshooting
+
+### Issue #3: ImportError with newer Ansible versions
+
+**Symptom:** `ImportError: cannot import name 'get_ini_config_value' from 'ansible.config.manager'`
+
+**Root Cause:** Ansible removed the `get_ini_config_value` function from its internal API (see [ansible/ansible#85404](https://github.com/ansible/ansible/pull/85404)).
+
+**Resolution:** The vault scripts (`vault-keyring.py` and `vault-keyring-client.py`) have been updated to use Python's standard `configparser` module instead of Ansible's private API. This makes them compatible with all Ansible versions.
 
 ### Issue #1: community.general.keyring fails on macOS with multiple Python versions
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,14 +3,17 @@
 # Install with: pip install -r requirements-dev.txt
 
 # Testing framework
-pytest>=8.0.0,<9.0.0
-pytest-cov>=4.1.0,<5.0.0
-pytest-mock>=3.12.0,<4.0.0
+pytest>=8.0.0
+pytest-cov>=6.0.0
+pytest-mock>=3.14.0
 
 # Code quality
-black>=26.3.1
-flake8>=7.0.0,<8.0.0
-pylint>=3.0.0,<4.0.0
+black>=25.1.0
+flake8>=7.0.0
+pylint>=3.0.0
+
+# Security auditing
+pip-audit>=2.7.0
 
 # Type checking (optional)
-mypy>=1.8.0,<2.0.0
+mypy>=1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,11 +5,8 @@
 
 # Keyring library for secure password storage
 # Provides interface to OS native keyring/keychain
-# Pinned to latest stable version for security patches
-keyring==25.6.0
+keyring>=25.6.0
 
 # Ansible for automation and vault functionality
-# Required for ConfigManager and vault operations
-# Pinned to latest stable version for security patches
-# Note: ansible 12.2.0 depends on ansible-core ~=2.19.4
-ansible==12.2.0
+# Required for vault operations and playbook execution
+ansible>=11.0.0

--- a/tests/test_vault_keyring.py
+++ b/tests/test_vault_keyring.py
@@ -1,0 +1,159 @@
+"""
+Tests for vault-keyring.py script.
+"""
+
+import configparser
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+# We need to import the functions from vault-keyring.py which has a hyphen in the name
+import importlib
+import importlib.util
+
+SCRIPT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _import_vault_keyring():
+    """Import vault-keyring.py as a module (handles hyphen in filename)."""
+    spec = importlib.util.spec_from_file_location(
+        "vault_keyring", os.path.join(SCRIPT_DIR, "vault-keyring.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    # Patch keyring import to avoid needing a real keyring backend
+    with patch.dict("sys.modules", {"keyring": MagicMock()}):
+        spec.loader.exec_module(module)
+    return module
+
+
+def _import_vault_keyring_client():
+    """Import vault-keyring-client.py as a module."""
+    spec = importlib.util.spec_from_file_location(
+        "vault_keyring_client", os.path.join(SCRIPT_DIR, "vault-keyring-client.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    with patch.dict("sys.modules", {"keyring": MagicMock()}):
+        spec.loader.exec_module(module)
+    return module
+
+
+class TestFindAnsibleCfg:
+    """Tests for _find_ansible_cfg function."""
+
+    def test_finds_ansible_cfg_via_env_var(self, tmp_path):
+        cfg_file = tmp_path / "custom_ansible.cfg"
+        cfg_file.write_text("[defaults]\n")
+        mod = _import_vault_keyring()
+        with patch.dict(os.environ, {"ANSIBLE_CONFIG": str(cfg_file)}):
+            result = mod._find_ansible_cfg()
+        assert result == str(cfg_file)
+
+    def test_env_var_missing_file_skipped(self, tmp_path):
+        mod = _import_vault_keyring()
+        with patch.dict(os.environ, {"ANSIBLE_CONFIG": "/nonexistent/ansible.cfg"}):
+            with patch("os.getcwd", return_value=str(tmp_path)):
+                result = mod._find_ansible_cfg()
+        assert result is None
+
+    def test_finds_ansible_cfg_in_cwd(self, tmp_path):
+        cfg_file = tmp_path / "ansible.cfg"
+        cfg_file.write_text("[defaults]\n")
+        mod = _import_vault_keyring()
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("ANSIBLE_CONFIG", None)
+            with patch("os.getcwd", return_value=str(tmp_path)):
+                result = mod._find_ansible_cfg()
+        assert result == str(cfg_file)
+
+    def test_returns_none_when_no_config(self, tmp_path):
+        mod = _import_vault_keyring()
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("ANSIBLE_CONFIG", None)
+            with patch("os.getcwd", return_value=str(tmp_path)):
+                with patch("os.path.isfile", return_value=False):
+                    result = mod._find_ansible_cfg()
+        assert result is None
+
+
+class TestGetVaultConfig:
+    """Tests for _get_vault_config function."""
+
+    def test_reads_vault_section(self, tmp_path):
+        cfg_file = tmp_path / "ansible.cfg"
+        cfg_file.write_text(
+            "[defaults]\n"
+            "inventory = hosts\n\n"
+            "[vault]\n"
+            "username = test_user\n"
+            "keyname = my_vault_key\n"
+        )
+        mod = _import_vault_keyring()
+        with patch.object(mod, "_find_ansible_cfg", return_value=str(cfg_file)):
+            username, keyname = mod._get_vault_config()
+        assert username == "test_user"
+        assert keyname == "my_vault_key"
+
+    def test_missing_vault_section(self, tmp_path):
+        cfg_file = tmp_path / "ansible.cfg"
+        cfg_file.write_text("[defaults]\ninventory = hosts\n")
+        mod = _import_vault_keyring()
+        with patch.object(mod, "_find_ansible_cfg", return_value=str(cfg_file)):
+            username, keyname = mod._get_vault_config()
+        assert username is None
+        assert keyname is None
+
+    def test_no_config_file(self):
+        mod = _import_vault_keyring()
+        with patch.object(mod, "_find_ansible_cfg", return_value=None):
+            username, keyname = mod._get_vault_config()
+        assert username is None
+        assert keyname is None
+
+    def test_partial_vault_section(self, tmp_path):
+        cfg_file = tmp_path / "ansible.cfg"
+        cfg_file.write_text("[vault]\nusername = only_user\n")
+        mod = _import_vault_keyring()
+        with patch.object(mod, "_find_ansible_cfg", return_value=str(cfg_file)):
+            username, keyname = mod._get_vault_config()
+        assert username == "only_user"
+        assert keyname is None
+
+
+class TestVaultKeyringClientArgParser:
+    """Tests for vault-keyring-client.py argument parser."""
+
+    def test_build_arg_parser_defaults(self):
+        mod = _import_vault_keyring_client()
+        parser = mod.build_arg_parser()
+        args = parser.parse_args([])
+        assert args.vault_id is None
+        assert args.username is None
+        assert args.set_password is False
+
+    def test_build_arg_parser_vault_id(self):
+        mod = _import_vault_keyring_client()
+        parser = mod.build_arg_parser()
+        args = parser.parse_args(["--vault-id", "my_vault"])
+        assert args.vault_id == "my_vault"
+
+    def test_build_arg_parser_username(self):
+        mod = _import_vault_keyring_client()
+        parser = mod.build_arg_parser()
+        args = parser.parse_args(["--username", "admin"])
+        assert args.username == "admin"
+
+    def test_build_arg_parser_set(self):
+        mod = _import_vault_keyring_client()
+        parser = mod.build_arg_parser()
+        args = parser.parse_args(["--set"])
+        assert args.set_password is True
+
+    def test_build_arg_parser_all_options(self):
+        mod = _import_vault_keyring_client()
+        parser = mod.build_arg_parser()
+        args = parser.parse_args(
+            ["--vault-id", "prod", "--username", "deploy", "--set"]
+        )
+        assert args.vault_id == "prod"
+        assert args.username == "deploy"
+        assert args.set_password is True

--- a/vault-keyring-client.py
+++ b/vault-keyring-client.py
@@ -62,44 +62,80 @@
 #
 # ansible-playbook --vault-id=keyring_id@/path/to/vault-keyring-client.py site.yml
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
 __metaclass__ = type
 
 import argparse
+import configparser
+import os
 import sys
 import getpass
 import keyring
 
-from ansible.config.manager import ConfigManager, get_ini_config_value
-
 KEYNAME_UNKNOWN_RC = 2
 
 
-def build_arg_parser():
-    parser = argparse.ArgumentParser(description='Get a vault password from user keyring')
+def _find_ansible_cfg():
+    """Find ansible.cfg using standard Ansible config search order."""
+    env_config = os.environ.get("ANSIBLE_CONFIG")
+    if env_config and os.path.isfile(env_config):
+        return env_config
+    cwd_cfg = os.path.join(os.getcwd(), "ansible.cfg")
+    if os.path.isfile(cwd_cfg):
+        return cwd_cfg
+    home_cfg = os.path.expanduser("~/.ansible.cfg")
+    if os.path.isfile(home_cfg):
+        return home_cfg
+    if os.path.isfile("/etc/ansible/ansible.cfg"):
+        return "/etc/ansible/ansible.cfg"
+    return None
 
-    parser.add_argument('--vault-id', action='store', default=None,
-                        dest='vault_id',
-                        help='name of the vault secret to get from keyring')
-    parser.add_argument('--username', action='store', default=None,
-                        help='the username whose keyring is queried')
-    parser.add_argument('--set', action='store_true', default=False,
-                        dest='set_password',
-                        help='set the password instead of getting it')
+
+def _get_vault_config():
+    """Read vault username and keyname from ansible.cfg [vault] section."""
+    cfg_path = _find_ansible_cfg()
+    if cfg_path is None:
+        return None, None
+    config = configparser.ConfigParser()
+    config.read(cfg_path)
+    username = config.get("vault", "username", fallback=None)
+    keyname = config.get("vault", "keyname", fallback=None)
+    return username, keyname
+
+
+def build_arg_parser():
+    parser = argparse.ArgumentParser(
+        description="Get a vault password from user keyring"
+    )
+
+    parser.add_argument(
+        "--vault-id",
+        action="store",
+        default=None,
+        dest="vault_id",
+        help="name of the vault secret to get from keyring",
+    )
+    parser.add_argument(
+        "--username",
+        action="store",
+        default=None,
+        help="the username whose keyring is queried",
+    )
+    parser.add_argument(
+        "--set",
+        action="store_true",
+        default=False,
+        dest="set_password",
+        help="set the password instead of getting it",
+    )
     return parser
 
 
 def main():
-    config = ConfigManager()
-    username = get_ini_config_value(
-        config._parsers[config._config_file],
-        dict(section='vault', key='username')
-    ) or getpass.getuser()
-
-    keyname = get_ini_config_value(
-        config._parsers[config._config_file],
-        dict(section='vault', key='keyname')
-    ) or 'ansible'
+    cfg_username, cfg_keyname = _get_vault_config()
+    username = cfg_username or getpass.getuser()
+    keyname = cfg_keyname or "ansible"
 
     arg_parser = build_arg_parser()
     args = arg_parser.parse_args()
@@ -113,24 +149,26 @@ def main():
         intro = 'Storing password in "{}" user keyring using key name: {}\n'
         sys.stdout.write(intro.format(username, keyname))
         password = getpass.getpass()
-        confirm = getpass.getpass('Confirm password: ')
+        confirm = getpass.getpass("Confirm password: ")
         if password == confirm:
             keyring.set_password(keyname, username, password)
         else:
-            sys.stderr.write('Passwords do not match\n')
+            sys.stderr.write("Passwords do not match\n")
             sys.exit(1)
     else:
         secret = keyring.get_password(keyname, username)
         if secret is None:
-            sys.stderr.write('vault-keyring-client could not find key="%s" for user="%s" via backend="%s"\n' %
-                             (keyname, username, keyring.get_keyring().name))
+            sys.stderr.write(
+                'vault-keyring-client could not find key="%s" for user="%s" via backend="%s"\n'
+                % (keyname, username, keyring.get_keyring().name)
+            )
             sys.exit(KEYNAME_UNKNOWN_RC)
 
         # print('secret: %s' % secret)
-        sys.stdout.write('%s\n' % secret)
+        sys.stdout.write("%s\n" % secret)
 
     sys.exit(0)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/vault-keyring.py
+++ b/vault-keyring.py
@@ -44,44 +44,65 @@
 #
 # ansible-playbook --vault-password-file=/path/to/vault-keyring.py site.yml
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
 __metaclass__ = type
 
+import configparser
+import os
 import sys
 import getpass
 import keyring
 
-from ansible.config.manager import ConfigManager, get_ini_config_value
+
+def _find_ansible_cfg():
+    """Find ansible.cfg using standard Ansible config search order."""
+    env_config = os.environ.get("ANSIBLE_CONFIG")
+    if env_config and os.path.isfile(env_config):
+        return env_config
+    cwd_cfg = os.path.join(os.getcwd(), "ansible.cfg")
+    if os.path.isfile(cwd_cfg):
+        return cwd_cfg
+    home_cfg = os.path.expanduser("~/.ansible.cfg")
+    if os.path.isfile(home_cfg):
+        return home_cfg
+    if os.path.isfile("/etc/ansible/ansible.cfg"):
+        return "/etc/ansible/ansible.cfg"
+    return None
+
+
+def _get_vault_config():
+    """Read vault username and keyname from ansible.cfg [vault] section."""
+    cfg_path = _find_ansible_cfg()
+    if cfg_path is None:
+        return None, None
+    config = configparser.ConfigParser()
+    config.read(cfg_path)
+    username = config.get("vault", "username", fallback=None)
+    keyname = config.get("vault", "keyname", fallback=None)
+    return username, keyname
 
 
 def main():
-    config = ConfigManager()
-    username = get_ini_config_value(
-        config._parsers[config._config_file],
-        dict(section='vault', key='username')
-    ) or getpass.getuser()
+    cfg_username, cfg_keyname = _get_vault_config()
+    username = cfg_username or getpass.getuser()
+    keyname = cfg_keyname or "ansible"
 
-    keyname = get_ini_config_value(
-        config._parsers[config._config_file],
-        dict(section='vault', key='keyname')
-    ) or 'ansible'
-
-    if len(sys.argv) == 2 and sys.argv[1] == 'set':
+    if len(sys.argv) == 2 and sys.argv[1] == "set":
         intro = 'Storing password in "{}" user keyring using key name: {}\n'
         sys.stdout.write(intro.format(username, keyname))
         password = getpass.getpass()
-        confirm = getpass.getpass('Confirm password: ')
+        confirm = getpass.getpass("Confirm password: ")
         if password == confirm:
             keyring.set_password(keyname, username, password)
         else:
-            sys.stderr.write('Passwords do not match\n')
+            sys.stderr.write("Passwords do not match\n")
             sys.exit(1)
     else:
-        sys.stdout.write('{0}\n'.format(keyring.get_password(keyname,
-                                                             username)))
+        sys.stdout.write("{0}\n".format(keyring.get_password(keyname, username)))
 
     sys.exit(0)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
Refactor vault-keyring.py and vault-keyring-client.py to remove dependency on Ansible's private `ConfigManager` and `get_ini_config_value` APIs, which were removed in newer Ansible versions. The scripts now use Python's standard `configparser` module to read vault configuration directly from ansible.cfg.

## Key Changes
- **Removed Ansible private API dependency**: Replaced `ansible.config.manager.ConfigManager` and `get_ini_config_value` with standard library `configparser`
- **Added config file discovery**: Implemented `_find_ansible_cfg()` function that searches for ansible.cfg in standard locations:
  - `ANSIBLE_CONFIG` environment variable
  - Current working directory
  - User home directory (~/.ansible.cfg)
  - System-wide location (/etc/ansible/ansible.cfg)
- **Added vault config parsing**: Implemented `_get_vault_config()` function that reads `[vault]` section from ansible.cfg to extract `username` and `keyname` settings
- **Code formatting**: Applied Black formatting standards to both scripts for consistency
- **Comprehensive test coverage**: Added 159 lines of test coverage in `tests/test_vault_keyring.py` with tests for:
  - Config file discovery logic
  - Vault configuration parsing
  - Argument parser functionality
- **Updated CI/CD**: Modernized GitHub Actions workflows to use ubuntu-latest, updated Python versions (3.10-3.13), and improved dependency management
- **Documentation**: Updated README with troubleshooting section explaining the issue and resolution

## Implementation Details
- Both scripts now follow the same configuration discovery pattern for consistency
- Fallback behavior preserved: defaults to current user and 'ansible' keyname if config not found
- All existing functionality maintained while improving compatibility with Ansible 12.x and newer versions
- Tests use dynamic module importing to handle hyphenated filenames and mock keyring dependency

https://claude.ai/code/session_01VZUCrgvPLnP9jwJG2bQSUZ

## Summary by Sourcery

Replace Ansible private configuration APIs in vault keyring scripts with direct config parsing while modernizing CI and documentation.

New Features:
- Add ansible.cfg discovery logic that searches standard locations for the configuration file.
- Add vault configuration parsing from the [vault] section of ansible.cfg to obtain username and key name for the keyring scripts.

Bug Fixes:
- Restore compatibility of vault-keyring scripts with newer Ansible versions that removed the get_ini_config_value API.

Enhancements:
- Unify configuration handling in vault-keyring.py and vault-keyring-client.py to use Python's configparser and preserve sensible defaults when config is missing.
- Apply consistent Black-style formatting across the vault keyring scripts.

CI:
- Update GitHub Actions workflows to run on ubuntu-latest with Python 3.10–3.13, modernize dependency installation, and tighten syntax, lint, coverage, and security checks.

Documentation:
- Clarify README wording and add troubleshooting guidance for ImportError caused by removed Ansible private APIs.

Tests:
- Add tests for ansible.cfg discovery, vault configuration parsing, and vault-keyring-client argument parsing, including dynamic importing of the scripts despite hyphenated filenames.

Chores:
- Relax and update keyring and Ansible dependency constraints in requirements.txt and document the resolved Ansible ImportError issue in CLAUDE.md.